### PR TITLE
Proposal for issue #3 "Make telemetry and caching configurable"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# Visual Studio Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Add the following repo to your `.pre-commit-config.yaml`:
 
 ## Configuration options
 
+### Specifying package categories
+
 This hook supports specifying [pipenv package
 categories](https://pipenv.pypa.io/en/latest/specifiers/#specifying-package-categories).
 In most cases, you'd just be interested in scanning the dependencies for the
@@ -62,4 +64,25 @@ check pipfile lock for insecure packages.................................Failed
 - exit code: 1
 
 Categories not found: staging
+```
+
+### Other options
+
+To reduce the load on pyup.io and to speed up unit testing the default options are to disable telemetry with caching set to 1hr.
+This is however configurable using the `--telemetry` and `--caching=` arguments
+
+```yaml
+- repo: https://github.com/kurthaegeman/pre-commit-hooks-safety-pipenv
+  rev: 0.0.1
+  hooks:
+    - id: pipenv-safety-check
+      args: ["--telemetry"]
+```
+
+```yaml
+- repo: https://github.com/kurthaegeman/pre-commit-hooks-safety-pipenv
+  rev: 0.0.1
+  hooks:
+    - id: pipenv-safety-check
+      args: ["--caching=1000"]
 ```


### PR DESCRIPTION
feat(telemetry/caching): add optional arguments for telemetry and caching configuration

test(telemetry/caching): add parse_commandline() tests for telemetry and caching configuration
refactor(process_lockdata): change process_lockdata() arguments to accept a argparse.Namespace instead of a list to allow for easier argument additions (and changed to appropriate tests